### PR TITLE
XRPL: Trustline create endpoint + env alignment (WALDO_CURRENCY, XRPL endpoint, distributor); widget wired

### DIFF
--- a/WordPress/waldocoin-stat-dash CURRENT.html
+++ b/WordPress/waldocoin-stat-dash CURRENT.html
@@ -4174,7 +4174,7 @@
       /** === DASHBOARD POPULATION === **/
       async function fetchUserStats(wallet) {
         try {
-          const res = await fetch(`${baseURL}/api/userStats?wallet=${wallet}`);
+          const res = await fetch(`${baseURL}/api/userstats?wallet=${wallet}`);
           const stats = await res.json();
           $("walletAddress") && ($("walletAddress").textContent = `Wallet: ${wallet}`);
           $("refCount") && ($("refCount").textContent = stats.referrals?.length ?? 0);

--- a/WordPress/widgets/waldo-dual-trade-widget.html
+++ b/WordPress/widgets/waldo-dual-trade-widget.html
@@ -875,9 +875,10 @@
 
     window.waldoTrustline = async function () {
       try {
-        const r = await fetch(`${API}/api/login/trustline-noripple`);
+        const r = await fetch(`${API}/api/xrpl/trustline/create`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
         const j = await r.json();
         console.log('📱 Trustline API Response:', j);
+        if (!j.success) throw new Error(j.error || 'Trustline failed');
         xummOpen('Add WALDO Trustline', j);  // Pass full response
       } catch (e) {
         alert('Trustline failed');

--- a/waldocoin-backend/routes/login/trustline-check.js
+++ b/waldocoin-backend/routes/login/trustline-check.js
@@ -25,7 +25,7 @@ router.get("/", async (req, res) => {
     });
 
     const ISSUER = process.env.WALDO_ISSUER || "rstjAWDiqKsUMhHqiJShRSkuaZ44TXZyDY";
-    const CURRENCY = (process.env.WALDOCOIN_TOKEN || "WLO").toUpperCase();
+    const CURRENCY = (process.env.WALDO_CURRENCY || process.env.WALDOCOIN_TOKEN || "WLO").toUpperCase();
 
     const hasWaldoTrustline = (response.result.lines || []).some((line) => {
       const cur = String(line.currency || '').trim().toUpperCase();

--- a/waldocoin-backend/routes/market/wlo.js
+++ b/waldocoin-backend/routes/market/wlo.js
@@ -33,8 +33,8 @@ router.get("/", async (_req, res) => {
     const client = new xrpl.Client("wss://xrplcluster.com");
     await client.connect();
 
-    const ISSUER = "rstjAWDiqKsUMhHqiJShRSkuaZ44TXZyDY";
-    const CURRENCY = "WLO";
+    const ISSUER = process.env.WALDO_ISSUER || "rstjAWDiqKsUMhHqiJShRSkuaZ44TXZyDY";
+    const CURRENCY = (process.env.WALDO_CURRENCY || "WLO").toUpperCase();
 
     // Ask: people selling WLO for XRP (WLO->XRP book)
     const wloToXrp = await client.request({

--- a/waldocoin-backend/routes/xrpl/trade.js
+++ b/waldocoin-backend/routes/xrpl/trade.js
@@ -16,7 +16,7 @@ router.post("/offer", async (req, res) => {
     }
     const DEST = (typeof destination === 'string' && destination.startsWith('r')) ? destination : undefined;
     const ISSUER = process.env.WALDO_ISSUER || "rstjAWDiqKsUMhHqiJShRSkuaZ44TXZyDY";
-    const CURRENCY = process.env.WALDOCOIN_TOKEN || "WLO";
+    const CURRENCY = (process.env.WALDO_CURRENCY || process.env.WALDOCOIN_TOKEN || "WLO").toUpperCase();
 
     const waldoPerXrpRaw = await getWaldoPerXrp().catch(() => null);
     // Prefer XRPL order book mid; if unavailable, fall back to Magnetic (if configured), else tiny default
@@ -24,7 +24,7 @@ router.post("/offer", async (req, res) => {
       const client = new xrpl.Client("wss://xrplcluster.com");
       await client.connect();
       const ISSUER = process.env.WALDO_ISSUER || "rstjAWDiqKsUMhHqiJShRSkuaZ44TXZyDY";
-      const CURRENCY = process.env.WALDOCOIN_TOKEN || "WLO";
+      const CURRENCY = (process.env.WALDO_CURRENCY || process.env.WALDOCOIN_TOKEN || "WLO").toUpperCase();
       const a = await client.request({ command: 'book_offers', taker_gets: { currency: 'XRP' }, taker_pays: { currency: CURRENCY, issuer: ISSUER }, limit: 5 });
       const b = await client.request({ command: 'book_offers', taker_gets: { currency: CURRENCY, issuer: ISSUER }, taker_pays: { currency: 'XRP' }, limit: 5 });
       await client.disconnect();

--- a/waldocoin-backend/utils/xrplClient.js
+++ b/waldocoin-backend/utils/xrplClient.js
@@ -5,7 +5,7 @@ let client;
 export async function getXrplClient() {
   try {
     if (!client || !client.isConnected()) {
-      client = new Client("wss://xrplcluster.com"); // 🌐 XRPL MAINNET
+      client = new Client(process.env.XRPL_ENDPOINT || process.env.XRPL_NODE || "wss://xrplcluster.com"); // 🌐 XRPL MAINNET
       await client.connect();
       console.log("✅ Connected to XRPL mainnet");
       // Attach disconnect handler once


### PR DESCRIPTION
What this PR does

- Add POST /api/xrpl/trustline/create to generate a Xaman TrustSet payload so users can add the WALDO trustline without leaving the Xaman app (web return_url is null)
- Wire the WordPress trade widget "Add Trustline" button to the new backend route
- Align env names across backend services to eliminate drift:
  - Prefer WALDO_CURRENCY (fallback: WALDOCOIN_TOKEN)
  - Read WALDO_ISSUER consistently
  - Accept both WALDO_DISTRIBUTOR_WALLET and DISTRIBUTOR_WALLET as the distributor address
  - XRPL client now reads XRPL_ENDPOINT or XRPL_NODE (defaults to wss://xrplcluster.com)
- Market endpoint now reads issuer/currency from env
- Autodistribute uses WALDO_CURRENCY from env (uppercased), continues to read WALDO_ISSUER and distributor wallet from env

Why

- Users reported "wallet not receiving WLO"; core blockers were env mismatches and missing trustline. This PR removes env naming ambiguity and enables a one-click trustline flow via Xaman.

Files changed (high-level)
- waldocoin-backend/routes/xrpl/trustline.js: add /create endpoint; import xummClient
- WordPress/widgets/waldo-dual-trade-widget.html: call /api/xrpl/trustline/create
- waldocoin-backend/autodistribute.js: use WALDO_CURRENCY env
- waldocoin-backend/routes/xrpl/trade.js + routes/login/trustline-check.js: prefer WALDO_CURRENCY
- waldocoin-backend/utils/xrplClient.js: use XRPL_ENDPOINT/XRPL_NODE
- waldocoin-backend/routes/market/wlo.js: issuer/currency via env

Deployment notes
- API service envs (no secrets here):
  - WALDO_ISSUER = rstjAWDiqKsUMhHqiJShRSkuaZ44TXZyDY
  - WALDO_CURRENCY = WLO
  - DISTRIBUTOR_WALLET = rMFoici99gcnXMjKwzJWP2WGe9bK4E5iLL
  - XRPL_ENDPOINT or XRPL_NODE optional
  - XUMM_API_KEY/SECRET required for payloads
- Autodistribute worker:
  - WALDO_SENDER_SECRET (treasury wallet seed that holds WLO), WALDO_ISSUER, WALDO_CURRENCY, DISTRIBUTOR_WALLET, REDIS_URL

Validation
- /api/market/wlo returns price
- /api/xrpl/trustline/create returns Xaman payload
- /api/xrpl/trustline/status?account=... reflects trustline
- /api/debug/autodistribute will show status/events once worker is running with REDIS_URL



---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author