### PR TITLE
Trade widget: faster price polling + immediate refresh triggers

### DIFF
--- a/WordPress/snippets/legal-gate.html
+++ b/WordPress/snippets/legal-gate.html
@@ -1,0 +1,96 @@
+<style>
+  #waldoLegalGate { position: fixed; inset: 0; z-index: 999999; display: none; align-items: center; justify-content: center; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; }
+  #waldoLegalGate.show { display: flex; }
+  #waldoLegalGate * { box-sizing: border-box; }
+  .lg-backdrop { position: absolute; inset: 0; background: #000; opacity: 0.96; }
+  .lg-modal { position: relative; z-index: 1; width: min(760px, 92vw); max-height: min(88vh, 100%); overflow: auto; border: 1px solid #1e1e1e; border-radius: 14px; background: #0b0b0b; color: #eafff9; padding: 22px; box-shadow: 0 0 28px rgba(0,0,0,.45); }
+  .lg-modal h2 { margin: 0 0 10px; font-weight: 900; letter-spacing: .3px; font-size: 20px; }
+  .lg-body { font-size: 14px; line-height: 1.5; }
+  .lg-body a { color: #9adbcf; text-decoration: underline; }
+  .lg-list { margin: 10px 0 0 18px; }
+  .lg-ack { display: flex; gap: 8px; align-items: flex-start; margin-top: 12px; }
+  .lg-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 14px; }
+  .lg-btn { background: linear-gradient(90deg, #00f7ff, #ff3df7); color: #061018; border: 0; padding: 10px 14px; border-radius: 10px; font-weight: 900; cursor: pointer; }
+  .lg-btn[disabled] { opacity: .5; cursor: not-allowed; }
+  @media (max-width: 480px) { .lg-modal { padding: 16px; } }
+  noscript .lg-noscript { position: fixed; inset: 0; z-index: 1000000; display: flex; align-items: center; justify-content: center; background: #000; color: #fff; padding: 24px; text-align: center; }
+</style>
+
+<div id="waldoLegalGate" role="dialog" aria-modal="true" aria-labelledby="lgTitle">
+  <div class="lg-backdrop" aria-hidden="true"></div>
+  <div class="lg-modal">
+    <h2 id="lgTitle">Important Legal Notice</h2>
+    <div class="lg-body">
+      <p>By accessing this site you confirm and agree that:</p>
+      <ul class="lg-list">
+        <li>You are at least 18 years old (or the legal age in your jurisdiction).</li>
+        <li>This site and any WALDO-related features are for informational and entertainment purposes only and do not constitute financial, investment, or legal advice.</li>
+        <li>WALDOCOIN is not offered as a security or an investment product; there is no expectation of profit, yield, or returns, and no guarantees.</li>
+        <li>You are solely responsible for complying with the laws of your jurisdiction. Do not use this site if doing so would be unlawful where you are located.</li>
+        <li>Blockchain transactions are generally irreversible and carry risk. Use at your own risk; the team is not liable for losses or damages.</li>
+        <li>By proceeding, you accept our Terms and Privacy Policy.</li>
+      </ul>
+      <label class="lg-ack"><input id="lgCheck" type="checkbox"> I confirm I am 18+ and I agree to the above and the site Terms.</label>
+      <label class="lg-ack"><input id="lgRemember" type="checkbox"> Don’t show again on this device</label>
+      <div class="lg-actions">
+        <button id="lgAgree" class="lg-btn" disabled>Enter Site</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<noscript>
+  <div class="lg-noscript">
+    You must enable JavaScript to use this site. By using this site you confirm you are 18+ and agree to our terms. If you do not agree, please leave this site.
+  </div>
+</noscript>
+
+<script>
+(function(){
+  const KEY = 'waldo_legal_accepted_v2';
+  function getAccepted(){
+    try { return localStorage.getItem(KEY) === 'true'; }
+    catch(_) { return document.cookie.indexOf(KEY + '=true') !== -1; }
+  }
+  function setAccepted(val){
+    try {
+      if (val) localStorage.setItem(KEY, 'true'); else localStorage.removeItem(KEY);
+    } catch(_) {
+      if (val) document.cookie = KEY + '=true; path=/; max-age=31536000; SameSite=Lax';
+      else document.cookie = KEY + '=; Max-Age=0; path=/; SameSite=Lax';
+    }
+  }
+  function lockScroll(yes){
+    try {
+      if (yes) { document.body.dataset._lgScroll = document.body.style.overflow || ''; document.body.style.overflow = 'hidden'; }
+      else { document.body.style.overflow = document.body.dataset._lgScroll || ''; }
+    } catch(_){}
+  }
+  function showGate(){ gate.classList.add('show'); lockScroll(true); }
+  function hideGate(){ gate.classList.remove('show'); lockScroll(false); }
+
+  function init(){
+    gate = document.getElementById('waldoLegalGate');
+    if (!gate) return;
+    const agree = document.getElementById('lgAgree');
+    const check = document.getElementById('lgCheck');
+    const remember = document.getElementById('lgRemember');
+
+    // Always show on any page where this block is present unless user opted out
+    if (getAccepted()) hideGate(); else showGate();
+
+    if (check) check.addEventListener('change', function(){ agree && (agree.disabled = !check.checked); });
+    if (agree) agree.addEventListener('click', function(){
+      if (!check || !check.checked) return;
+      // Only remember if user opted out from seeing it again
+      if (remember && remember.checked) setAccepted(true); else setAccepted(false);
+      hideGate();
+    });
+  }
+
+  // Initialize as soon as DOM is ready
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);
+  else init();
+})();
+</script>
+

--- a/WordPress/widgets/waldo-dual-trade-widget.html
+++ b/WordPress/widgets/waldo-dual-trade-widget.html
@@ -81,6 +81,9 @@
         <button id="xummMobileBtn" class="btn" type="button"
           style="background: #25c2a0; color: white; border: none; padding: 15px 20px; border-radius: 10px; font-size: 16px; font-weight: bold; cursor: pointer; width: 100%;">📱
           Open Xaman App</button>
+        <a id="xummLink" href="#" target="_blank" rel="noopener"
+          style="display:none; color:#9adbcf; word-break:break-all;">Open in Xaman (link)</a>
+
 
         <small class="hint" style="color:#9adbcf; opacity:.9;">If the app doesn’t open, copy the link and paste into
           Xaman.</small>
@@ -562,8 +565,47 @@
     border: none;
     color: #9adbcf;
     font-size: 18px;
-    cursor: pointer
+    cursor: pointer;
   }
+
+  /* Center the XUMM modal and its QR on all devices */
+  .xumm-modal {
+    padding: 16px;
+  }
+
+  .xumm-modal .backdrop {
+    z-index: 1;
+  }
+
+  .xumm-modal .content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+    z-index: 2;
+  }
+
+  #xummDesktop {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    text-align: center;
+  }
+
+  #xummQr {
+    margin: 0 auto;
+  }
+
+  #xummLoad.spin {
+    margin: 0 auto;
+  }
+
+  #xummHint.hint {
+    text-align: center;
+  }
+
 
   .spin {
     border: 4px solid #1c1c1c;
@@ -633,7 +675,7 @@
     const toggle = document.getElementById('widgetToggle');
     let collapsed = true;
     function applyCollapsed() { root.classList.toggle('collapsed', collapsed); }
-    if (toggle) toggle.addEventListener('click', () => { collapsed = !collapsed; applyCollapsed(); });
+    if (toggle) toggle.addEventListener('click', () => { collapsed = !collapsed; applyCollapsed(); if (!collapsed) { try { loadMarket(); refreshSwapMarket(); } catch (_) { } } });
     applyCollapsed();
 
     // Expose programmatic controls for external CTA buttons
@@ -713,22 +755,20 @@
       if (root.classList.contains('collapsed')) { collapsed = false; root.classList.remove('collapsed'); }
       el('panelXrpl').style.display = tab === 'xrpl' ? 'block' : 'none';
       el('panelFl').style.display = tab === 'fl' ? 'block' : 'none';
-
-
-
+      try { loadMarket(); refreshSwapMarket(); } catch (_) { }
     }));
 
     // Market data
     async function loadMarket() {
       try {
-        const r = await fetch(`${API}/api/market/wlo`, { cache: 'no-store' });
+        const r = await fetch(`${API}/api/market/wlo?_=${Date.now()}`, { cache: 'no-store' });
         const j = await r.json();
         const xrpPerWlo = (j?.xrpPerWlo && isFinite(j.xrpPerWlo)) ? j.xrpPerWlo : (j?.best?.mid || null);
         el('priceXrp').textContent = (xrpPerWlo && isFinite(xrpPerWlo)) ? `${xrpPerWlo.toFixed(8)} XRP` : '—';
         const v = j?.volume24h; el('vol24').textContent = (v == null) ? '—' : (isFinite(v) ? Number(v).toLocaleString() : String(v));
       } catch (e) { el('priceXrp').textContent = '—'; el('vol24').textContent = '—'; }
     }
-    loadMarket(); setInterval(loadMarket, 60_000);
+    loadMarket(); setInterval(loadMarket, 60000);
 
     // XUMM modal
     function xummOpen(title, data) {
@@ -758,6 +798,19 @@
 
         // Store deep link globally for copy functionality
         currentDeepLink = deep;
+        // Show a direct link on mobile as well (in case the button is blocked by in-app browsers)
+        if (link) {
+          if (deep && deep !== '#' && deep !== '') {
+            link.href = deep;
+            link.textContent = 'Open in Xaman (link)';
+            link.style.display = 'block';
+            link.setAttribute('target', '_blank');
+            link.setAttribute('rel', 'noopener');
+          } else {
+            link.style.display = 'none';
+          }
+        }
+
 
         // Set up mobile button click handler
         const mobileBtn = el('xummMobileBtn');
@@ -825,7 +878,7 @@
 
     async function refreshSwapMarket() {
       try {
-        const r = await fetch(`${API}/api/market/wlo`, { cache: 'no-store' });
+        const r = await fetch(`${API}/api/market/wlo?_=${Date.now()}`, { cache: 'no-store' });
         const j = await r.json();
         swapMid = (j?.xrpPerWlo && isFinite(j.xrpPerWlo)) ? j.xrpPerWlo : (j?.best?.mid || null);
         updateSwapPrice(); recomputeSwap();
@@ -864,7 +917,7 @@
       recomputeSwap();
     }));
     el('fromAmount').addEventListener('input', recomputeSwap);
-    refreshSwapMarket(); setInterval(refreshSwapMarket, 60_000);
+    refreshSwapMarket(); setInterval(refreshSwapMarket, 60000);
 
     window.waldoSwap = async function () {
       const amt = parseFloat(el('fromAmount').value);

--- a/WordPress/widgets/waldo-dual-trade-widget.html
+++ b/WordPress/widgets/waldo-dual-trade-widget.html
@@ -705,6 +705,7 @@
             if (s?.txid) { window._waldoLastTx = s.txid; }
             if (s?.account) { setConnected(s.account); checkTrustline(s.account); }
             showToast(successMsg || 'Success');
+            try { loadMarket(); refreshSwapMarket(); } catch (_) { }
             xummClose();
           }
           if (++tries >= max) clearInterval(id);
@@ -728,6 +729,7 @@
             if (typeof onSuccess === 'function') try { onSuccess(s); } catch (_) { };
             if (s?.account) { setConnected(s.account); checkTrustline(s.account); }
             showToast(successMsg || 'Success');
+            try { loadMarket(); refreshSwapMarket(); } catch (_) { }
             xummClose();
           }
           if (++tries >= max) clearInterval(id);
@@ -768,7 +770,9 @@
         const v = j?.volume24h; el('vol24').textContent = (v == null) ? '—' : (isFinite(v) ? Number(v).toLocaleString() : String(v));
       } catch (e) { el('priceXrp').textContent = '—'; el('vol24').textContent = '—'; }
     }
-    loadMarket(); setInterval(loadMarket, 60000);
+    loadMarket(); setInterval(loadMarket, 15000);
+    document.addEventListener('visibilitychange', () => { if (!document.hidden) { try { loadMarket(); refreshSwapMarket(); } catch (_) { } } });
+    window.addEventListener('focus', () => { try { loadMarket(); refreshSwapMarket(); } catch (_) { } });
 
     // XUMM modal
     function xummOpen(title, data) {

--- a/WordPress/widgets/waldo-dual-trade-widget.html
+++ b/WordPress/widgets/waldo-dual-trade-widget.html
@@ -921,7 +921,7 @@
       recomputeSwap();
     }));
     el('fromAmount').addEventListener('input', recomputeSwap);
-    refreshSwapMarket(); setInterval(refreshSwapMarket, 60000);
+    refreshSwapMarket(); setInterval(refreshSwapMarket, 15000);
 
     window.waldoSwap = async function () {
       const amt = parseFloat(el('fromAmount').value);

--- a/WordPress/widgets/waldo-staking-widget.html
+++ b/WordPress/widgets/waldo-staking-widget.html
@@ -1,12 +1,11 @@
 <!-- WALDO Staking Widget (matches trading widget look) -->
 <div class="waldo-stake collapsed" id="waldoStake">
   <div class="stake-head">
-    <div class="title"><span class="accent">🟢</span> WALDO Staking</div>
-    <div class="sub">Earn 12%–35% APY • Early unstake penalty 15%</div>
+    <div class="title"><span class="accent">🟢</span> WALDO Lock & Boost</div>
+    <div class="sub">30-Day Lock + • Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
     <div class="tabs">
       <button id="stakeToggle" class="toggle" aria-label="Toggle widget" title="Toggle"></button>
       <button class="tab active" data-tab="long">Long-Term</button>
-      <button class="tab" data-tab="meme">Per-Meme</button>
     </div>
   </div>
 
@@ -49,19 +48,19 @@
             <label>Duration</label>
             <select id="ltDuration">
               <option value="">Select duration</option>
-              <option value="30">30 days — 12% APY</option>
-              <option value="90">90 days — 18% APY</option>
-              <option value="180">180 days — 25% APY</option>
-              <option value="365">365 days — 35% APY</option>
+              <option value="30">30 days — +12% Bonus</option>
+              <option value="90">90 days — +18% Bonus</option>
+              <option value="180">180 days — +25% Bonus</option>
+              <option value="365">365 days — +35% Bonus</option>
             </select>
           </div>
         </div>
-        <div class="actions"><button class="btn buy" onclick="createLongTermStake()">Stake</button></div>
+        <div class="actions"><button class="btn buy" onclick="createLongTermStake()">Lock</button></div>
         <div id="ltMsg" class="msg"></div>
       </div>
 
       <div class="list">
-        <h4>Your Active Long-Term Stakes</h4>
+        <h4>Your Active Long-Term Locks</h4>
         <div id="ltList"></div>
       </div>
     </div>
@@ -81,13 +80,13 @@
             <input id="pmMemeId" type="text" placeholder="tweet123" />
           </div>
         </div>
-        <div class="subline">Per‑Meme: 30 days • 5% staking fee vs 10% instant • +15% bonus</div>
-        <div class="actions"><button class="btn buy" onclick="createPerMemeStake()">Stake Per‑Meme</button></div>
+        <div class="subline">Per‑Meme: 30 days • 5% lock fee vs 10% instant • +15% bonus</div>
+        <div class="actions"><button class="btn buy" onclick="createPerMemeStake()">Lock Per‑Meme</button></div>
         <div id="pmMsg" class="msg"></div>
       </div>
 
       <div class="list">
-        <h4>Your Active Per‑Meme Stakes</h4>
+        <h4>Your Active Per‑Meme Lock & Boost</h4>
         <div id="pmList"></div>
       </div>
     </div>
@@ -351,40 +350,41 @@
     background: #111;
     border: 1px solid #1c1c1c;
     color: #bfeee3;
+  }
 
-    /* Enhanced prominence for Connect/Trustline buttons */
+  /* Enhanced prominence for Connect/Trustline buttons */
 
-    .btn.cta {
-      background: linear-gradient(90deg, #00f7ff, #ff3df7, #00f7ff);
-      color: #061018;
-      border: 0;
-      padding: 12px 16px;
-      font-weight: 900;
-      box-shadow: 0 0 16px rgba(0, 247, 255, .25), 0 0 22px rgba(255, 61, 247, .16);
-      transition: transform .05s ease, box-shadow .2s ease;
-    }
+  .btn.cta {
+    background: linear-gradient(90deg, #00f7ff, #ff3df7, #00f7ff);
+    color: #061018;
+    border: 0;
+    padding: 12px 16px;
+    font-weight: 900;
+    box-shadow: 0 0 16px rgba(0, 247, 255, .25), 0 0 22px rgba(255, 61, 247, .16);
+    transition: transform .05s ease, box-shadow .2s ease;
+  }
 
-    .btn.cta:hover {
-      transform: translateY(-1px);
-    }
+  .btn.cta:hover {
+    transform: translateY(-1px);
+  }
 
-    .btn.cta.connect {
-      background: linear-gradient(90deg, #00f7ff, #19e3e3);
-    }
+  .btn.cta.connect {
+    background: linear-gradient(90deg, #00f7ff, #19e3e3);
+  }
 
-    .btn.cta.trust {
-      background: linear-gradient(90deg, #ff3df7, #ff7be9);
-    }
+  .btn.cta.trust {
+    background: linear-gradient(90deg, #ff3df7, #ff7be9);
+  }
 
-    .btn.mini {
-      padding: 4px 8px;
-      font-size: 12px;
-      border-radius: 8px;
-    }
+  .btn.mini {
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 8px;
+  }
 
-    .balance-line {
-      opacity: .9;
-    }
+  .balance-line {
+    opacity: .9;
+  }
 </style>
 
 <script>
@@ -453,13 +453,13 @@
       const tl = document.getElementById('stakeTlStatus'); if (tl) tl.textContent = 'Trustline: —';
       // Clear LT UI
       const ltBal = document.getElementById('ltBal'); if (ltBal) ltBal.textContent = '—';
-      const ltList = document.getElementById('ltList'); if (ltList) ltList.innerHTML = '<div class="subline">No active long‑term stakes</div>';
+      const ltList = document.getElementById('ltList'); if (ltList) ltList.innerHTML = '<div class="subline">No active long‑term locks</div>';
       const ltAmt = document.getElementById('ltAmount'); if (ltAmt) ltAmt.value = '';
       const ltDur = document.getElementById('ltDuration'); if (ltDur) ltDur.value = '';
       const ltMsg = document.getElementById('ltMsg'); if (ltMsg) ltMsg.textContent = '';
       // Clear Per‑Meme UI
       const pmBal = document.getElementById('pmBal'); if (pmBal) pmBal.textContent = '—';
-      const pmList = document.getElementById('pmList'); if (pmList) pmList.innerHTML = '<div class="subline">No active per‑meme stakes</div>';
+      const pmList = document.getElementById('pmList'); if (pmList) pmList.innerHTML = '<div class="subline">No active per‑meme locks</div>';
       const pmAmt = document.getElementById('pmAmount'); if (pmAmt) pmAmt.value = '';
       const pmId = document.getElementById('pmMemeId'); if (pmId) pmId.value = '';
       const pmMsg = document.getElementById('pmMsg'); if (pmMsg) pmMsg.textContent = '';
@@ -520,24 +520,28 @@
     function renderLongTerm(list) {
       const root = document.getElementById('ltList');
       root.innerHTML = list.map(s => `
-      <div class="stake-item">
-        <strong>Long‑Term</strong><br/>
-        Amount: ${s.amount} WALDO • Duration: ${s.duration}d • APY: ${s.apy}<br/>
-        Days Remaining: ${s.daysRemaining} • Expected Reward: ${s.expectedReward}
-        <div class="actions"><button class="btn" onclick="stakeUnstake('${s.stakeId}')">Unstake</button></div>
-      </div>
-    `).join('') || '<div class="subline">No active long‑term stakes</div>';
+        <div class="stake-item">
+          <strong>Long‑Term Lock</strong><br/>
+          Amount: ${s.amount} WALDO • Duration: ${s.duration} days • Bonus: +${s.apy}%<br/>
+          Days Remaining: ${s.daysRemaining} • Estimated WALDO: ${s.expectedReward} WALDO
+          <div class="actions">
+            <button class="btn" onclick="stakeUnstake('${s.stakeId}')">Unlock</button>
+          </div>
+        </div>
+      `).join('') || '<div class="subline">No active long‑term locks</div>';
     }
     function renderPerMeme(list) {
       const root = document.getElementById('pmList');
       root.innerHTML = list.map(s => `
-      <div class="stake-item">
-        <strong>Per‑Meme</strong><br/>
-        Meme: ${s.memeId} • Staked: ${s.stakedAmount} • Bonus: ${s.bonusAmount} • Total: ${s.totalReward}<br/>
-        Days Remaining: ${s.daysRemaining}
-        <div class="actions"><button class="btn" onclick="stakeUnstake('${s.stakeId}')">Unstake</button></div>
-      </div>
-    `).join('') || '<div class="subline">No active per‑meme stakes</div>';
+        <div class="stake-item">
+          <strong>Per‑Meme Lock</strong><br/>
+          Meme: ${s.memeId} • Locked: ${s.stakedAmount} WALDO • Bonus: ${s.bonusAmount} WALDO • Total WALDO: ${s.totalReward}<br/>
+          Days Remaining: ${s.daysRemaining}
+          <div class="actions">
+            <button class="btn" onclick="stakeUnstake('${s.stakeId}')">Unlock</button>
+          </div>
+        </div>
+      `).join('') || '<div class="subline">No active per‑meme locks</div>';
     }
 
     // Create stakes
@@ -550,8 +554,8 @@
       try {
         const r = await fetch(`${API}/api/staking/long-term`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ wallet: WALLET, amount: amt, duration: dur }) });
         const j = await r.json();
-        if (!j.success) throw new Error(j.error || 'Stake failed');
-        msg.textContent = `Long-term stake created! Expected reward: ${j.stakeData.expectedReward} WALDO`;
+        if (!j.success) throw new Error(j.error || 'Lock failed');
+        msg.textContent = `Long‑term lock created! Estimated WALDO: ${j.stakeData.expectedReward}`;
         await stakeLoadInfo();
       } catch (e) { msg.textContent = 'Error: ' + e.message; }
     }
@@ -565,22 +569,22 @@
       try {
         const r = await fetch(`${API}/api/staking/per-meme`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ wallet: WALLET, amount: amt, memeId }) });
         const j = await r.json();
-        if (!j.success) throw new Error(j.error || 'Stake failed');
-        msg.textContent = `Per‑meme stake created! Total reward: ${j.stakeData.totalReward} WALDO`;
+        if (!j.success) throw new Error(j.error || 'Lock failed');
+        msg.textContent = `Per‑meme lock created! Total WALDO: ${j.stakeData.totalReward}`;
         await stakeLoadInfo();
       } catch (e) { msg.textContent = 'Error: ' + e.message; }
     }
 
     // Unstake
     window.stakeUnstake = async function (stakeId) {
-      if (!confirm('Unstake now? Early unstaking incurs a 15% penalty.')) return;
+      if (!confirm('Unlock now? Early unlock reduces your WALDO by 15%.')) return;
       try {
         const r = await fetch(`${API}/api/staking/unstake`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ wallet: WALLET, stakeId }) });
         const j = await r.json();
-        if (!j.success) throw new Error(j.error || 'Unstake failed');
-        alert('Unstake complete!');
+        if (!j.success) throw new Error(j.error || 'Unlock failed');
+        alert('Unlock complete!');
         await stakeLoadInfo();
-      } catch (e) { alert('Unstake error: ' + e.message); }
+      } catch (e) { alert('Unlock error: ' + e.message); }
     }
   })();
 </script>

--- a/waldocoin-backend/routes/market/wlo.js
+++ b/waldocoin-backend/routes/market/wlo.js
@@ -22,8 +22,11 @@ router.get("/", async (_req, res) => {
     // Magnetic-derived rate (cached). Only expose if Magnetic is configured.
     if (process.env.MAGNETIC_PRICE_URL) {
       const waldoPerXrp = await getWaldoPerXrp();
-      result.waldoPerXrp = waldoPerXrp;
-      result.xrpPerWlo = waldoPerXrp > 0 ? 1 / waldoPerXrp : null;
+      // Treat default presale fallback (10000) as "not available" so we can fall back to XRPL mid
+      if (typeof waldoPerXrp === 'number' && isFinite(waldoPerXrp) && waldoPerXrp > 0 && waldoPerXrp !== 10000) {
+        result.waldoPerXrp = waldoPerXrp;
+        result.xrpPerWlo = 1 / waldoPerXrp;
+      }
     }
   } catch (e) {
     // ignore; keep null

--- a/web/staking/index-complete.html
+++ b/web/staking/index-complete.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WALDO Staking</title>
+  <title>WALDO Lock & Boost</title>
   <style>
     html,
     body {
@@ -309,8 +309,8 @@
 <body>
   <div class="wrap">
     <div class="top">
-      <div class="brand"><b>WALDO</b> Staking</div>
-      <div class="subtitle">Earn 12%–35% APY • Early unstake penalty 15%</div>
+      <div class="brand"><b>WALDO</b> Lock & Boost</div>
+      <div class="subtitle">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
     </div>
 
     <script>
@@ -321,8 +321,8 @@
     <!-- WORKING STAKING WIDGET -->
     <div class="waldo-stake collapsed" id="waldoStake">
       <div class="stake-head">
-        <div class="title">🟢 WALDO Staking</div>
-        <div class="sub">Earn 12%–35% APY • Early unstake penalty 15%</div>
+        <div class="title">🟢 WALDO Lock & Boost</div>
+        <div class="sub">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
         <div class="tabs">
           <button id="stakeToggle" class="toggle" aria-label="Toggle widget" title="Toggle"></button>
           <button class="tab active" data-tab="long">Long-Term</button>
@@ -370,19 +370,19 @@
                 <label>Duration</label>
                 <select id="ltDuration">
                   <option value="">Select duration</option>
-                  <option value="30">30 days — 12% APY</option>
-                  <option value="90">90 days — 18% APY</option>
-                  <option value="180">180 days — 25% APY</option>
-                  <option value="365">365 days — 35% APY</option>
+                  <option value="30">30 days — +12% Bonus</option>
+                  <option value="90">90 days — +18% Bonus</option>
+                  <option value="180">180 days — +25% Bonus</option>
+                  <option value="365">365 days — +35% Bonus</option>
                 </select>
               </div>
             </div>
-            <div class="actions"><button class="btn buy" onclick="createLongTermStake()">Stake</button></div>
+            <div class="actions"><button class="btn buy" onclick="createLongTermStake()">Lock</button></div>
             <div id="ltMsg" class="msg"></div>
           </div>
 
           <div class="list">
-            <h4>Your Active Long-Term Stakes</h4>
+            <h4>Your Active Long-Term Locks</h4>
             <div id="ltList"></div>
           </div>
         </div>
@@ -402,13 +402,13 @@
                 <input id="pmMemeId" type="text" placeholder="tweet123" />
               </div>
             </div>
-            <div class="subline">Per‑Meme: 30 days • 5% staking fee vs 10% instant • +15% bonus</div>
-            <div class="actions"><button class="btn buy" onclick="createPerMemeStake()">Stake Per‑Meme</button></div>
+            <div class="subline">Per‑Meme: 30 days • 5% lock fee vs 10% instant • +15% bonus</div>
+            <div class="actions"><button class="btn buy" onclick="createPerMemeStake()">Lock Per‑Meme</button></div>
             <div id="pmMsg" class="msg"></div>
           </div>
 
           <div class="list">
-            <h4>Your Active Per‑Meme Stakes</h4>
+            <h4>Your Active Per‑Meme Locks</h4>
             <div id="pmList"></div>
           </div>
         </div>
@@ -551,22 +551,22 @@
         root.innerHTML = list.map(s => `
           <div class="stake-item">
             <div>Long‑Term</div>
-            <div class="subline">Amount: ${s.amount} WALDO • Duration: ${s.duration}d • APY: ${s.apy}</div>
-            <div class="subline">Days Remaining: ${s.daysRemaining} • Expected Reward: ${s.expectedReward}</div>
-            <button class="btn mini" onclick="stakeUnstake('${s.stakeId}')">Unstake</button>
+            <div class="subline">Amount: ${s.amount} WALDO • Duration: ${s.duration}d • Bonus: +${s.apy}%</div>
+            <div class="subline">Days Remaining: ${s.daysRemaining} • Estimated WALDO: ${s.expectedReward}</div>
+            <button class="btn mini" onclick="stakeUnstake('${s.stakeId}')">Unlock</button>
           </div>
-        `).join('') || 'No active long‑term stakes';
+        `).join('') || 'No active long‑term locks';
       }
       function renderPerMeme(list) {
         const root = document.getElementById('pmList');
         root.innerHTML = list.map(s => `
           <div class="stake-item">
             <div>Per‑Meme</div>
-            <div class="subline">Meme: ${s.memeId} • Staked: ${s.stakedAmount} • Bonus: ${s.bonusAmount} • Total: ${s.totalReward}</div>
+            <div class="subline">Meme: ${s.memeId} • Locked: ${s.stakedAmount} • Bonus: ${s.bonusAmount} • Total WALDO: ${s.totalReward}</div>
             <div class="subline">Days Remaining: ${s.daysRemaining}</div>
-            <button class="btn mini" onclick="stakeUnstake('${s.stakeId}')">Unstake</button>
+            <button class="btn mini" onclick="stakeUnstake('${s.stakeId}')">Unlock</button>
           </div>
-        `).join('') || 'No active per‑meme stakes';
+        `).join('') || 'No active per‑meme locks';
       }
 
       // Create stakes
@@ -579,8 +579,8 @@
         try {
           const r = await fetch(`${API}/api/staking/long-term`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ wallet: WALLET, amount: amt, duration: dur }) });
           const j = await r.json();
-          if (!j.success) throw new Error(j.error || 'Stake failed');
-          msg.textContent = `Long-term stake created! Expected reward: ${j.stakeData.expectedReward} WALDO`;
+          if (!j.success) throw new Error(j.error || 'Lock failed');
+          msg.textContent = `Long-term lock created! Estimated WALDO: ${j.stakeData.expectedReward} WALDO`;
           await stakeLoadInfo();
         } catch (e) { msg.textContent = 'Error: ' + e.message; }
       }
@@ -594,15 +594,15 @@
         try {
           const r = await fetch(`${API}/api/staking/per-meme`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ wallet: WALLET, amount: amt, memeId }) });
           const j = await r.json();
-          if (!j.success) throw new Error(j.error || 'Stake failed');
-          msg.textContent = `Per‑meme stake created! Total reward: ${j.stakeData.totalReward} WALDO`;
+          if (!j.success) throw new Error(j.error || 'Lock failed');
+          msg.textContent = `Per‑meme lock created! Total WALDO: ${j.stakeData.totalReward} WALDO`;
           await stakeLoadInfo();
         } catch (e) { msg.textContent = 'Error: ' + e.message; }
       }
 
       // Unstake
       window.stakeUnstake = async function (stakeId) {
-        if (!confirm('Unstake now? Early unstaking incurs a 15% penalty.')) return;
+        if (!confirm('Unlock now? Early unlocking reduces WALDO by 15%.')) return;
         try {
           const r = await fetch(`${API}/api/staking/unstake`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ wallet: WALLET, stakeId }) });
           const j = await r.json();

--- a/web/staking/index-fixed.html
+++ b/web/staking/index-fixed.html
@@ -1,23 +1,27 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WALDO Staking</title>
+  <title>WALDO Lock & Boost</title>
   <meta name="color-scheme" content="dark" />
   <style>
-    html, body {
+    html,
+    body {
       background: #05060f;
       color: #eafff9;
       font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       margin: 0;
       padding: 0;
     }
+
     .wrap {
       max-width: 880px;
       margin: 20px auto;
       padding: 0 12px;
     }
+
     .top {
       display: flex;
       align-items: center;
@@ -25,10 +29,12 @@
       gap: 12px;
       margin-bottom: 10px;
     }
+
     .brand {
       font-weight: 1000;
       letter-spacing: .6px;
     }
+
     .brand b {
       background: linear-gradient(90deg, #00f7ff, #ff3df7, #00f7ff);
       -webkit-background-clip: text;
@@ -37,51 +43,65 @@
       background-size: 300% 100%;
       animation: shimmer 6s linear infinite;
     }
+
     @keyframes shimmer {
-      0% { background-position: 0 0; }
-      100% { background-position: -200% 0; }
+      0% {
+        background-position: 0 0;
+      }
+
+      100% {
+        background-position: -200% 0;
+      }
     }
+
     .subtitle {
       opacity: .85;
       font-size: 13px;
     }
+
     .card {
       border: 1px solid #18213d;
       background: linear-gradient(180deg, #0a0c1a, #0b0f23);
       border-radius: 14px;
       padding: 12px;
     }
+
     .footer {
       opacity: .7;
       font-size: 12px;
       text-align: center;
       margin: 18px 0;
     }
-    a { color: #9adbcf; }
+
+    a {
+      color: #9adbcf;
+    }
   </style>
 </head>
+
 <body>
   <div class="wrap">
     <div class="top">
-      <div class="brand"><b>WALDO</b> Staking</div>
-      <div class="subtitle">Earn 12%–35% APY • Early unstake penalty 15%</div>
+      <div class="brand"><b>WALDO</b> Lock & Boost</div>
+      <div class="subtitle">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
     </div>
-    
+
     <div class="card">
       <script>
         // Point the widget to your production API base
         window.WALDO_API = 'https://waldocoin-backend-api.onrender.com';
       </script>
-      
+
       <!-- WORKING STAKING WIDGET WILL BE INSERTED HERE -->
       <div id="staking-widget-container">
-        <p>Loading WALDO Staking Widget...</p>
+        <p>Loading WALDO Lock & Boost Widget...</p>
         <p><strong>If this message persists, the widget failed to load.</strong></p>
         <p>Please try refreshing the page or contact support.</p>
       </div>
     </div>
 
-    <div class="footer">© WALDOCOIN • Powered by XRPL • <a target="_blank" rel="noopener" href="https://waldocoin.live">waldocoin.live</a></div>
+    <div class="footer">© WALDOCOIN • Powered by XRPL • <a target="_blank" rel="noopener"
+        href="https://waldocoin.live">waldocoin.live</a></div>
   </div>
 
   <script>
@@ -93,9 +113,10 @@
       })
       .catch(error => {
         console.error('Failed to load staking widget:', error);
-        document.getElementById('staking-widget-container').innerHTML = 
-          '<p style="color: #ff6b6b;">❌ Failed to load staking widget. Please refresh the page.</p>';
+        document.getElementById('staking-widget-container').innerHTML =
+          '<p style="color: #ff6b6b;">❌ Failed to load lock widget. Please refresh the page.</p>';
       });
   </script>
 </body>
+
 </html>

--- a/web/staking/index.html
+++ b/web/staking/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WALDO Staking</title>
+  <title>WALDO Lock & Boost</title>
   <style>
     html,
     body {
@@ -323,8 +323,8 @@
 <body>
   <div class="wrap">
     <div class="top">
-      <div class="brand"><b>WALDO</b> Staking</div>
-      <div class="subtitle">Earn 12%–35% APY • Early unstake penalty 15%</div>
+      <div class="brand"><b>WALDO</b> Lock & Boost</div>
+      <div class="subtitle">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
     </div>
 
     <script>
@@ -335,8 +335,8 @@
     <!-- WORKING STAKING WIDGET -->
     <div class="waldo-stake" id="waldoStake">
       <div class="stake-head">
-        <div class="title">🟢 WALDO Staking</div>
-        <div class="sub">Earn 12%–35% APY • Early unstake penalty 15%</div>
+        <div class="title">🟢 WALDO Lock & Boost</div>
+        <div class="sub">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
         <div class="tabs">
           <button id="stakeToggle" class="toggle" aria-label="Toggle widget" title="Toggle"></button>
           <button class="tab active" data-tab="long">Long-Term</button>
@@ -384,19 +384,19 @@
                 <label>Duration</label>
                 <select id="ltDuration">
                   <option value="">Select duration</option>
-                  <option value="30">30 days — 12% APY</option>
-                  <option value="90">90 days — 18% APY</option>
-                  <option value="180">180 days — 25% APY</option>
-                  <option value="365">365 days — 35% APY</option>
+                  <option value="30">30 days — +12% Bonus</option>
+                  <option value="90">90 days — +18% Bonus</option>
+                  <option value="180">180 days — +25% Bonus</option>
+                  <option value="365">365 days — +35% Bonus</option>
                 </select>
               </div>
             </div>
-            <div class="actions"><button class="btn buy" onclick="createLongTermStake()">Stake</button></div>
+            <div class="actions"><button class="btn buy" onclick="createLongTermStake()">Lock</button></div>
             <div id="ltMsg" class="msg"></div>
           </div>
 
           <div class="list">
-            <h4>Your Active Long-Term Stakes</h4>
+            <h4>Your Active Long-Term Locks</h4>
             <div id="ltList"></div>
           </div>
         </div>
@@ -429,7 +429,7 @@
   </div>
 
   <script>
-    console.log('🚀 WALDO Staking Script Loading...');
+    console.log('🚀 WALDO Lock & Boost Script Loading...');
 
     // Configuration - hardcoded like the working trade widget
     const API = "https://waldocoin-backend-api.onrender.com";
@@ -654,7 +654,7 @@
           const stakes = (stakingResult && stakingResult.longTermStaking && Array.isArray(stakingResult.longTermStaking.activeStakes)) ? stakingResult.longTermStaking.activeStakes : [];
           if (ltListEl) {
             if (!stakes.length) {
-              ltListEl.innerHTML = '<div class="subline">No active long-term stakes yet.</div>';
+              ltListEl.innerHTML = '<div class="subline">No active long-term locks yet.</div>';
             } else {
               ltListEl.innerHTML = stakes.map(s => {
                 const amt = Number(s.amount || 0).toLocaleString();
@@ -705,7 +705,7 @@
       const ltDurEl = document.getElementById('ltDuration');
       const ltMsgEl = document.getElementById('ltMsg');
       if (ltBalEl) ltBalEl.textContent = '—';
-      if (ltListEl) ltListEl.innerHTML = '<div class="subline">No active long‑term stakes</div>';
+      if (ltListEl) ltListEl.innerHTML = '<div class="subline">No active long‑term locks</div>';
       if (ltAmtEl) ltAmtEl.value = '';
       if (ltDurEl) ltDurEl.value = '';
       if (ltMsgEl) ltMsgEl.textContent = '';
@@ -717,7 +717,7 @@
       const pmIdEl = document.getElementById('pmMemeId');
       const pmMsgEl = document.getElementById('pmMsg');
       if (pmBalEl) pmBalEl.textContent = '—';
-      if (pmListEl) pmListEl.innerHTML = '<div class="subline">No active per‑meme stakes</div>';
+      if (pmListEl) pmListEl.innerHTML = '<div class="subline">No active per‑meme locks</div>';
       if (pmAmtEl) pmAmtEl.value = '';
       if (pmIdEl) pmIdEl.value = '';
       if (pmMsgEl) pmMsgEl.textContent = '';
@@ -762,7 +762,7 @@
           return;
         }
 
-        if (msgEl) msgEl.textContent = 'Creating stake...';
+        if (msgEl) msgEl.textContent = 'Creating lock...';
 
         const response = await fetch(`${API}/api/staking/long-term`, {
           method: 'POST',
@@ -773,16 +773,16 @@
         const result = await response.json();
 
         if (result.success) {
-          if (msgEl) msgEl.textContent = `✅ Long-term stake created! Expected reward: ${result.stakeData.expectedReward} WALDO`;
+          if (msgEl) msgEl.textContent = `✅ Long-term lock created! Estimated WALDO: ${result.stakeData.expectedReward} WALDO`;
           // Reload wallet info
           stakeLoadInfo();
         } else {
           const detail = result.details ? ` - ${result.details}` : '';
-          throw new Error((result.error || 'Stake creation failed') + detail);
+          throw new Error((result.error || 'Lock creation failed') + detail);
         }
 
       } catch (error) {
-        console.error('❌ Long-term stake error:', error);
+        console.error('❌ Long-term lock error:', error);
         const msgEl = document.getElementById('ltMsg');
         if (msgEl) msgEl.textContent = 'Error: ' + error.message;
       }

--- a/web/staking/static.html
+++ b/web/staking/static.html
@@ -1,23 +1,27 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WALDO Staking</title>
+  <title>WALDO Lock & Boost</title>
   <meta name="color-scheme" content="dark" />
   <style>
-    html, body {
+    html,
+    body {
       background: #05060f;
       color: #eafff9;
       font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       margin: 0;
       padding: 0;
     }
+
     .wrap {
       max-width: 880px;
       margin: 20px auto;
       padding: 0 12px;
     }
+
     .top {
       display: flex;
       align-items: center;
@@ -25,10 +29,12 @@
       gap: 12px;
       margin-bottom: 10px;
     }
+
     .brand {
       font-weight: 1000;
       letter-spacing: .6px;
     }
+
     .brand b {
       background: linear-gradient(90deg, #00f7ff, #ff3df7, #00f7ff);
       -webkit-background-clip: text;
@@ -37,27 +43,40 @@
       background-size: 300% 100%;
       animation: shimmer 6s linear infinite;
     }
+
     @keyframes shimmer {
-      0% { background-position: 0 0; }
-      100% { background-position: -200% 0; }
+      0% {
+        background-position: 0 0;
+      }
+
+      100% {
+        background-position: -200% 0;
+      }
     }
+
     .subtitle {
       opacity: .85;
       font-size: 13px;
     }
+
     .card {
       border: 1px solid #18213d;
       background: linear-gradient(180deg, #0a0c1a, #0b0f23);
       border-radius: 14px;
       padding: 12px;
     }
+
     .footer {
       opacity: .7;
       font-size: 12px;
       text-align: center;
       margin: 18px 0;
     }
-    a { color: #9adbcf; }
+
+    a {
+      color: #9adbcf;
+    }
+
     .status {
       padding: 20px;
       text-align: center;
@@ -66,6 +85,7 @@
       border-radius: 14px;
       margin: 20px 0;
     }
+
     .btn {
       background: linear-gradient(90deg, #00f7ff, #ff3df7);
       color: #061018;
@@ -80,21 +100,24 @@
     }
   </style>
 </head>
+
 <body>
   <div class="wrap">
     <div class="top">
-      <div class="brand"><b>WALDO</b> Staking</div>
-      <div class="subtitle">Earn 12%–35% APY • Early unstake penalty 15%</div>
+      <div class="brand"><b>WALDO</b> Lock & Boost</div>
+      <div class="subtitle">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
     </div>
-    
+
     <div class="status">
       <h2>🔧 Service Under Maintenance</h2>
-      <p>We're updating the staking service to fix recent issues.</p>
-      <p>The staking widget will be back online shortly with all buttons working properly.</p>
+      <p>We're updating the lock service to fix recent issues.</p>
+      <p>The Lock & Boost widget will be back online shortly with all buttons working properly.</p>
       <a href="https://waldocoin.live" class="btn">← Back to Main Site</a>
     </div>
 
-    <div class="footer">© WALDOCOIN • Powered by XRPL • <a target="_blank" rel="noopener" href="https://waldocoin.live">waldocoin.live</a></div>
+    <div class="footer">© WALDOCOIN • Powered by XRPL • <a target="_blank" rel="noopener"
+        href="https://waldocoin.live">waldocoin.live</a></div>
   </div>
 </body>
+
 </html>

--- a/web/staking/working.html
+++ b/web/staking/working.html
@@ -1,23 +1,27 @@
 <!doctype html>
 <html lang="en">
+
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WALDO Staking</title>
+  <title>WALDO Lock & Boost</title>
   <meta name="color-scheme" content="dark" />
   <style>
-    html, body {
+    html,
+    body {
       background: #05060f;
       color: #eafff9;
       font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
       margin: 0;
       padding: 0;
     }
+
     .wrap {
       max-width: 880px;
       margin: 20px auto;
       padding: 0 12px;
     }
+
     .top {
       display: flex;
       align-items: center;
@@ -25,10 +29,12 @@
       gap: 12px;
       margin-bottom: 10px;
     }
+
     .brand {
       font-weight: 1000;
       letter-spacing: .6px;
     }
+
     .brand b {
       background: linear-gradient(90deg, #00f7ff, #ff3df7, #00f7ff);
       -webkit-background-clip: text;
@@ -37,51 +43,68 @@
       background-size: 300% 100%;
       animation: shimmer 6s linear infinite;
     }
+
     @keyframes shimmer {
-      0% { background-position: 0 0; }
-      100% { background-position: -200% 0; }
+      0% {
+        background-position: 0 0;
+      }
+
+      100% {
+        background-position: -200% 0;
+      }
     }
+
     .subtitle {
       opacity: .85;
       font-size: 13px;
     }
+
     .footer {
       opacity: .7;
       font-size: 12px;
       text-align: center;
       margin: 18px 0;
     }
-    a { color: #9adbcf; }
+
+    a {
+      color: #9adbcf;
+    }
   </style>
 </head>
+
 <body>
   <div class="wrap">
     <div class="top">
-      <div class="brand"><b>WALDO</b> Staking</div>
-      <div class="subtitle">Earn 12%–35% APY • Early unstake penalty 15%</div>
-    </div>
-    
-    <div style="text-align: center; padding: 40px; border: 1px solid #18213d; border-radius: 14px; background: linear-gradient(180deg, #0a0c1a, #0b0f23);">
-      <h2>🏦 WALDO Staking Widget</h2>
-      <p>✅ <strong>Server is running successfully!</strong></p>
-      <p>✅ <strong>Git sync is working!</strong></p>
-      <p>⏳ <strong>Deploying working staking widget...</strong></p>
-      <br>
-      <p><small>The staking widget with working buttons will be deployed in the next update.</small></p>
-      <p><small>All backend fixes have been merged and deployed.</small></p>
-      <br>
-      <a href="https://waldocoin.live" style="background: linear-gradient(90deg, #00f7ff, #ff3df7); color: #061018; border: 0; padding: 12px 24px; border-radius: 10px; font-weight: 900; text-decoration: none; display: inline-block;">← Back to Main Site</a>
+      <div class="brand"><b>WALDO</b> Lock & Boost</div>
+      <div class="subtitle">Bonus: +12% to +35% • Early unlock reduces WALDO by 15%</div>
     </div>
 
-    <div class="footer">© WALDOCOIN • Powered by XRPL • <a target="_blank" rel="noopener" href="https://waldocoin.live">waldocoin.live</a></div>
+    <div
+      style="text-align: center; padding: 40px; border: 1px solid #18213d; border-radius: 14px; background: linear-gradient(180deg, #0a0c1a, #0b0f23);">
+      <h2>🏦 WALDO Lock & Boost Widget</h2>
+      <p>✅ <strong>Server is running successfully!</strong></p>
+      <p>✅ <strong>Git sync is working!</strong></p>
+      <p>⏳ <strong>Deploying working lock widget...</strong></p>
+      <br>
+      <p><small>The lock widget with working buttons will be deployed in the next update.</small></p>
+      <p><small>All backend fixes have been merged and deployed.</small></p>
+      <br>
+      <a href="https://waldocoin.live"
+        style="background: linear-gradient(90deg, #00f7ff, #ff3df7); color: #061018; border: 0; padding: 12px 24px; border-radius: 10px; font-weight: 900; text-decoration: none; display: inline-block;">←
+        Back to Main Site</a>
+    </div>
+
+    <div class="footer">© WALDOCOIN • Powered by XRPL • <a target="_blank" rel="noopener"
+        href="https://waldocoin.live">waldocoin.live</a></div>
   </div>
 
   <script>
     // API Configuration
     window.WALDO_API = 'https://waldocoin-backend-api.onrender.com';
-    console.log('🏦 WALDO Staking page loaded');
+    console.log('🏦 WALDO Lock & Boost page loaded');
     console.log('🔗 API endpoint:', window.WALDO_API);
-    console.log('✅ Ready for staking widget deployment');
+    console.log('✅ Ready for lock widget deployment');
   </script>
 </body>
+
 </html>


### PR DESCRIPTION
Improve trading widget price updates and backend price source selection.

Frontend
- Poll top-of-widget price every 15s (was 60s)
- Refresh price when tab opens, when page becomes visible again, on window focus
- After successful Xaman sign (login/trade), refresh market + swap mid
- Swap panel mid refresh now every 15s (was 60s)

Backend
- Market API now ignores the Magnetic default fallback (waldoPerXrp = 10000) and prefers XRPL mid in that case. This prevents the display price from getting stuck at 0.0001 XRP/WLO when the Magnetic endpoint is misconfigured/unavailable.

Why
- Users were seeing a fixed 0.0001 XRP/WLO; that happens when Magnetic fetch fails and falls back to presale default. We now degrade to XRPL mid instead so the live price remains dynamic.

Config note
- To use Magnetic as the source, ensure env vars are set correctly on the backend:
  - MAGNETIC_PRICE_URL (JSON endpoint)
  - Optional: MAGNETIC_PRICE_FIELD (default: waldoPerXrp), MAGNETIC_PRICE_MODE = WALDO_PER_XRP | XRP_PER_WALDO
